### PR TITLE
Add time delay for running do_ocr.py

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -7,3 +7,4 @@ wiki_password = WikiSource Password
 wikisource_language_code = language code in two letters
 keep_temp_folder_in_google_drive = no
 edit_summary = Text from Google OCR
+delay = 1

--- a/do_ocr.py
+++ b/do_ocr.py
@@ -74,7 +74,7 @@ logging.info("Operating System = " + os_version)
 
 
 
-
+time.sleep(1)
 
 #Read the config file
 
@@ -84,6 +84,7 @@ wiki_username = config.get('settings','wiki_username')
 wiki_password = config.get('settings','wiki_password')
 wikisource_language_code = config.get('settings','wikisource_language_code')
 keep_temp_folder_in_google_drive = config.get('settings','keep_temp_folder_in_google_drive')
+delay = config.get('settings','delay')
 #start_page = config.get('settings','start_page')
 #end_page = config.get('settings','end_page')
 
@@ -95,6 +96,7 @@ logger.info("Wiki Username = " + wiki_username)
 logger.info("Wiki Password = " + "Not logging the password")
 logger.info("Wiki Source Language Code = " + wikisource_language_code )
 logger.info("Keep Temp folder in  Google Drive = " + keep_temp_folder_in_google_drive)
+logger.info("Delay = " + delay)
 #logger.info("Start Page = " + str(start_page))
 #logger.info("End Page = " + str(end_page))
 
@@ -239,6 +241,10 @@ def move_file(file):
         logger.info(message)
 
 
+#Pause the tool while running many parallel sessions
+
+delay = float(delay)
+time.sleep(delay)
 
 
 # Create a temp folder in google drive to upload the files. You can delete this folder later.
@@ -274,9 +280,6 @@ for filename in glob.glob('page_*.pdf'):
 #    for pageno in range(int(start_page),len(files) +1):
 #        pages.append("page_" + str(pageno).zfill(5) + ".pdf")
         
-
-
-
 
 
 

--- a/do_ocr.py
+++ b/do_ocr.py
@@ -73,9 +73,6 @@ for line in os_info:
 logging.info("Operating System = " + os_version)
 
 
-
-time.sleep(1)
-
 #Read the config file
 
 url = config.get('settings','file_url')

--- a/mediawiki_uploader.py
+++ b/mediawiki_uploader.py
@@ -227,7 +227,7 @@ for text_file in sorted(files):
         
         message = "Uploaded at https://" + wikisource_language_code + ".wikisource.org/wiki/Page:" + pagename + "\n"
 	logging.info(message)
-        time.sleep(5)
+        time.sleep(1)
         logging.info("=========")
 
 
@@ -268,6 +268,6 @@ logger.removeHandler(handler)
 handler.flush()
 handler.close()
 
-time.sleep(2)
+time.sleep(1)
 
 clean_folders()


### PR DESCRIPTION
This change adds a time delay for running do_ocr.py . This will help to run tens of terminals over night and let them start at different intervals so as not to overload the Google Drive API. When there are unequal files at the end of one run, the time delay value needs to be altered. It will be better if do_ocr.py could be changed so that it ignores this delay value during its second run.
